### PR TITLE
feat:API 호출 횟수를 줄이기(#2)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,19 @@
 import { useEffect, useState } from 'react';
 
-import * as S from './components/style';
-import useInput from './hooks/useInput';
 import getSearchedData from './api';
 import { SearchedData } from './@types';
+import { useDebounce, useInput } from './hooks';
+
+import * as S from './components/style';
 
 const App = () => {
   const { value: keyword, onChange, clear } = useInput('');
   const [searchedList, setSearchedList] = useState<Array<SearchedData>>();
   const [error, setError] = useState<string>();
+  const debouncedValue = useDebounce(keyword, 500);
 
   const searching = async () => {
-    const res = await getSearchedData(keyword);
+    const res = await getSearchedData(debouncedValue);
     if (res.isSuccess && res.data) {
       setError('');
       setSearchedList(res.data);
@@ -23,7 +25,7 @@ const App = () => {
 
   useEffect(() => {
     searching();
-  }, [keyword]);
+  }, [debouncedValue]);
 
   return (
     <S.Container>

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -4,6 +4,8 @@ import BASE_URL from './BASE_URL';
 const getSearchedData = async (keyword: string): Promise<APIResponse> => {
   try {
     if (keyword) {
+      // eslint-disable-next-line no-console
+      console.info('calling api');
       const res = await fetch(`${BASE_URL}/?name=${keyword}`, {
         method: 'GET',
         headers: {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,4 @@
-export {};
+import useDebounce from './userDebounce';
+import useInput from './useInput';
+
+export { useInput, useDebounce };

--- a/src/hooks/userDebounce.ts
+++ b/src/hooks/userDebounce.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+const useDebounce = (value: string, dealy: number): string => {
+  const [debouncedValue, setDebouncedValue] = useState<string>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, dealy);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, dealy]);
+
+  return debouncedValue;
+};
+export default useDebounce;


### PR DESCRIPTION
## 🚀 PR Type

- [x] Feature

## 🤹‍♀️ What is the current behavior?

- [x] 디바운싱 Hook 생성후 연결
- [x] API를 호출할 때 마다 console.info("calling api") 출력

Issue Number: #2 closed

## 📸 Screenshots
https://user-images.githubusercontent.com/60846068/235976791-7048cf68-83fd-4937-b51c-c735e5a242ac.mov


## 💬 Other information

apit 호출을 줄이기 위해서 debounce 기능을 사용함
1. 사용자가 검색할 때마다 api 호출이 미뤄짐
2. 사용자가 검색어를 입력후, 500ms 동안 추가 입력 없을 시에 api 호출