### PR TITLE
feat:키보드만으로 추천 검색어들로 이동 가능하도록 구현(#4)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { SearchedData } from './@types';
 import { useCahingData, useDebounce, useInput } from './hooks';
@@ -10,6 +10,9 @@ const App = () => {
   const { value: keyword, onChange, clear } = useInput('');
   const [searchedList, setSearchedList] = useState<Array<SearchedData>>();
   const debouncedValue = useDebounce(keyword, 500);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const searchedDataRef = useRef<(HTMLDivElement | null)[]>([]);
+  const filteredSearchDataRef = { current: searchedDataRef.current?.filter((x) => x !== null) };
 
   const searching = async () => {
     const seachedData = await useCahingData(debouncedValue);
@@ -22,19 +25,53 @@ const App = () => {
     searching();
   }, [debouncedValue]);
 
+  const handleDataKeyDown = (event: React.KeyboardEvent, idx: number) => {
+    if (event.code === 'ArrowDown') {
+      filteredSearchDataRef.current[idx + 1]?.focus();
+    }
+    if (event.code === 'ArrowUp') {
+      if (idx === 0) {
+        inputRef.current?.focus();
+      }
+      filteredSearchDataRef.current[idx - 1]?.focus();
+    }
+  };
+  const handleInputKeyDown = (event: React.KeyboardEvent) => {
+    if (event.code === 'ArrowDown' && event.nativeEvent.isComposing === false) {
+      event.preventDefault();
+      filteredSearchDataRef.current[0]?.focus();
+    }
+  };
+
   return (
     <S.Container>
       <S.Title>
         국내 모든 임상시험 검색하고 <br /> 온라인으로 참여하기
       </S.Title>
-      <SeachInput inputChange={onChange} inputValue={keyword} inpuClear={clear} />
-      <S.SearchedList>
-        {searchedList &&
-          searchedList?.map((searched) => (
-            <S.SeachedData key={searched.id}>{searched.name}</S.SeachedData>
+      <SeachInput
+        inputRef={inputRef}
+        handleInputKeyDown={handleInputKeyDown}
+        inputChange={onChange}
+        inputValue={keyword}
+        inpuClear={clear}
+      />
+      {debouncedValue && searchedList && (
+        <S.SearchedList>
+          {searchedList?.length === 0 && <S.SeachedData>검색어 없음</S.SeachedData>}
+          {searchedList?.map((data, idx) => (
+            <S.SeachedData
+              key={data.id}
+              ref={(el) => {
+                filteredSearchDataRef.current[idx] = el;
+              }}
+              tabIndex={idx}
+              onKeyDown={(e) => handleDataKeyDown(e, idx)}
+            >
+              {data.name}
+            </S.SeachedData>
           ))}
-        {debouncedValue && searchedList?.length === 0 && <S.SeachedData>검색어 없음</S.SeachedData>}
-      </S.SearchedList>
+        </S.SearchedList>
+      )}
     </S.Container>
   );
 };

--- a/src/components/SeachInput.tsx
+++ b/src/components/SeachInput.tsx
@@ -1,15 +1,29 @@
+import { RefObject } from 'react';
 import * as S from './style';
 
 interface SeachInputProps {
   inputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   inputValue: string;
   inpuClear: () => void;
+  handleInputKeyDown: (event: React.KeyboardEvent) => void;
+  inputRef: RefObject<HTMLInputElement>;
 }
 
-const SeachInput = ({ inputChange, inputValue, inpuClear }: SeachInputProps) => {
+const SeachInput = ({
+  inputChange,
+  inputValue,
+  inpuClear,
+  handleInputKeyDown,
+  inputRef,
+}: SeachInputProps) => {
   return (
     <S.SearchWrapper>
-      <S.Input onChange={inputChange} value={inputValue} />
+      <S.Input
+        ref={inputRef}
+        onKeyDown={handleInputKeyDown}
+        onChange={inputChange}
+        value={inputValue}
+      />
       <S.Button onClick={inpuClear}>X</S.Button>
       <S.Button>검색</S.Button>
     </S.SearchWrapper>

--- a/src/components/style.ts
+++ b/src/components/style.ts
@@ -27,11 +27,12 @@ export const Button = styled.button`
   width: 40px;
   height: 40px;
 `;
-export const SearchedList = styled.ul`
+export const SearchedList = styled.div`
   width: 100%;
+  display: flex;
+  flex-direction: column;
   justify-content: start;
 `;
-export const SeachedData = styled.li`
-  list-style: none;
-  margin-bottom: 10px;
+export const SeachedData = styled.div`
+  margin-top: 10px;
 `;


### PR DESCRIPTION
## 🚀 PR Type

- [x] Feature

## 🤹‍♀️ What is the current behavior?

- [x] 키보드만으로 추천 검색어들로 이동 가능하도록 구현


Issue Number: #4 closed

## 📸 Screenshots

https://user-images.githubusercontent.com/60846068/235985850-386ca8f2-fefc-4487-8591-a5bdb6abc549.mov

## 💬 Other information
input 창부터 추천검색어 전부 위/아래 방향키로 foucs를 이동시킬 수 있음
- useRef 로 구현했으며, parameter 값을 변경할 수 없다는 lint rule 로 인하여 컴포넌트화의 어려움을 가짐
- 관심사분리가 필요해 보임